### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,25 +1,25 @@
 # Datatypes (KEYWORD1)
 
 # Methods and Functions (KEYWORD2)
-begin KEYWORD2
-clear KEYWORD2
-home KEYWORD2
-setCursor KEYWORD2
-write KEYWORD2
-cursor KEYWORD2
-noCursor KEYWORD2
-blink KEYWORD2
-noBlink KEYWORD2
-display KEYWORD2
-noDisplay KEYWORD2
-backlight KEYWORD2
-noBacklight KEYWORD2
-scrollDisplayLeft KEYWORD2
-scrollDisplayRight KEYWORD2
-autoscroll KEYWORD2
-noAutoscroll KEYWORD2
-leftToRight KEYWORD2
-rightToLeft KEYWORD2
-createChar KEYWORD2
+begin	KEYWORD2
+clear	KEYWORD2
+home	KEYWORD2
+setCursor	KEYWORD2
+write	KEYWORD2
+cursor	KEYWORD2
+noCursor	KEYWORD2
+blink	KEYWORD2
+noBlink	KEYWORD2
+display	KEYWORD2
+noDisplay	KEYWORD2
+backlight	KEYWORD2
+noBacklight	KEYWORD2
+scrollDisplayLeft	KEYWORD2
+scrollDisplayRight	KEYWORD2
+autoscroll	KEYWORD2
+noAutoscroll	KEYWORD2
+leftToRight	KEYWORD2
+rightToLeft	KEYWORD2
+createChar	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords